### PR TITLE
Move PR lists down to the job configuration

### DIFF
--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbGitHubAuth.java
@@ -198,11 +198,13 @@ public class GhprbGitHubAuth extends AbstractDescribableImpl<GhprbGitHubAuth> {
     }
 
     public GitHub getConnection(Item context) throws IOException {
-        if (gh == null) {
-            buildConnection(context);
+        synchronized (credentialsId) {
+            if (gh == null) {
+                buildConnection(context);
+            }
+            
+            return gh;
         }
-        
-        return gh;
     }
 
     @Override

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -174,7 +174,16 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
      * Save any updates that may have been made inside the plugin that would affect the config.xml
      */
     public void save() {
-        if (super.job == null) {
+        if (super.job == null || pullRequests == null) {
+            return;
+        }
+        boolean save = false;
+        for (GhprbPullRequest pr : pullRequests.values()) {
+            if (save || pr.isChanged()) {
+                pr.save();
+            }
+        }
+        if (!save) {
             return;
         }
         try {

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -178,6 +178,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         boolean save = false;
         for (GhprbPullRequest pr : pullRequests.values()) {
             if (save || pr.isChanged()) {
+                save = true;
                 pr.save();
             }
         }
@@ -185,6 +186,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             return;
         }
         try {
+            logger.log(Level.FINEST, "Saving config update for job");
             super.job.save();
         } catch (IOException e) {
             logger.log(Level.SEVERE, "Unable to save config updates", e);

--- a/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/GhprbTrigger.java
@@ -48,13 +48,11 @@ import javax.servlet.ServletException;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.WeakHashMap;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentMap;
 import java.util.logging.Level;
 import java.util.logging.Logger;
 import java.util.regex.Pattern;
@@ -201,7 +199,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         try {
             Map<Integer, GhprbPullRequest> prs = getDescriptor().getPullRequests(project.getFullName());
             if (prs != null) {
-                prs = new HashMap<Integer, GhprbPullRequest>(prs);
+                prs = new ConcurrentHashMap<Integer, GhprbPullRequest>(prs);
                 if (pullRequests == null) {
                     pullRequests = prs;
                 } else {
@@ -244,7 +242,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
     public Map<Integer, GhprbPullRequest> getPullRequests() {
         if (pullRequests == null) {
-            pullRequests = new HashMap<Integer, GhprbPullRequest>();
+            pullRequests = new ConcurrentHashMap<Integer, GhprbPullRequest>();
         }
         return pullRequests;
     }
@@ -633,7 +631,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
         private String requestForTestingPhrase;
 
         // map of jobs (by their fullName) and their map of pull requests
-        private transient Map<String, ConcurrentMap<Integer, GhprbPullRequest>> jobs;
+        private transient Map<String, Map<Integer, GhprbPullRequest>> jobs;
         
         /**
          *  map of jobs (by the repo name);  No need to keep the projects from shutdown to startup.
@@ -664,10 +662,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
             if (repoJobs == null) {
                 repoJobs = new ConcurrentHashMap<String, Set<AbstractProject<?, ?>>>();
             }
-//            if (jobs == null) {
-//                jobs = new HashMap<String, ConcurrentMap<Integer, GhprbPullRequest>>();
-//            }
-//            save();
+            save();
         }
 
         @Override
@@ -811,7 +806,7 @@ public class GhprbTrigger extends GhprbTriggerBackwardsCompatible {
 
         public Map<Integer, GhprbPullRequest> getPullRequests(String projectName) {
             Map<Integer, GhprbPullRequest> ret = null;
-            if (jobs.containsKey(projectName)) {
+            if (jobs != null && jobs.containsKey(projectName)) {
                 ret = jobs.get(projectName);
                 jobs.remove(projectName);
             }

--- a/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
+++ b/src/main/java/org/jenkinsci/plugins/ghprb/jobdsl/GhprbContextExtensionPoint.java
@@ -38,7 +38,8 @@ public class GhprbContextExtensionPoint extends ContextExtensionPoint {
                 null,
                 null,
                 null,
-                context.extensionContext.extensions
+                context.extensionContext.extensions,
+                null
         );
     }
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbITBaseTestCase.java
@@ -73,6 +73,7 @@ public abstract class GhprbITBaseTestCase {
         
 
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(newArrayList(ghPullRequest)).willReturn(newArrayList(ghPullRequest));
+        given(ghRepository.getPullRequest(Mockito.anyInt())).willReturn(ghPullRequest);
 
         given(ghUser.getEmail()).willReturn("email@email.com");
         given(ghUser.getLogin()).willReturn("user");

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbPullRequestMergeTest.java
@@ -118,7 +118,7 @@ public class GhprbPullRequestMergeTest {
         jobs.put("project", pulls);
 
         Mockito.doReturn(project).when(trigger).getActualProject();
-        Mockito.doReturn(pulls).when(trigger).getPulls();
+        Mockito.doReturn(pulls).when(trigger).getPullRequests();
         Mockito.doReturn(repo).when(trigger).getRepository();
         Mockito.doReturn(pr).when(repo).getPullRequest(pullId);
         
@@ -161,7 +161,7 @@ public class GhprbPullRequestMergeTest {
         jobsField.set(descriptor, jobs);
 
         helper = spy(new Ghprb(trigger));
-        given(trigger.getPulls()).willReturn(pulls);
+        given(trigger.getPullRequests()).willReturn(pulls);
         trigger.setHelper(helper);
         given(helper.getRepository()).willReturn(repo);
         given(helper.isBotUser(any(GHUser.class))).willReturn(false);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -239,6 +239,7 @@ public class GhprbRepositoryTest {
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(1)).getPullRequests(OPEN); // Call to Github API
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
+        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -321,6 +322,7 @@ public class GhprbRepositoryTest {
         verify(builds, times(1)).build(any(GhprbPullRequest.class), any(GHUser.class), any(String.class));
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
         verify(ghRepository, times(1)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
+        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
@@ -413,6 +415,7 @@ public class GhprbRepositoryTest {
         
         verify(ghRepository, times(2)).getPullRequests(eq(OPEN)); // Call to Github API
         verify(ghRepository, times(2)).createCommitStatus(eq("head sha"), eq(PENDING), eq(""), eq(msg), eq("default")); // Call to Github API
+        verify(ghRepository, times(1)).getPullRequest(Mockito.anyInt());
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -247,7 +247,8 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
-        verify(ghPullRequest, times(3)).getUpdatedAt();
+        verify(ghPullRequest, times(2)).getUpdatedAt();
+        verify(ghPullRequest, times(1)).getCreatedAt();
         verify(ghPullRequest, times(1)).getHtmlUrl();
         verify(ghPullRequest, times(1)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
@@ -283,13 +284,13 @@ public class GhprbRepositoryTest {
         mockCommitList();
         GhprbBuilds builds = mockBuilds();
         
-        Date now = new Date();
+        Date later = new DateTime().plusHours(3).toDate();
         Date tomorrow = new DateTime().plusDays(1).toDate();
 
 
         given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
 
-        given(ghPullRequest.getUpdatedAt()).willReturn(now).willReturn(now).willReturn(tomorrow);
+        given(ghPullRequest.getUpdatedAt()).willReturn(later).willReturn(tomorrow);
         given(ghPullRequest.getNumber()).willReturn(100);
         given(ghPullRequest.getMergeable()).willReturn(true);
         given(ghPullRequest.getTitle()).willReturn("title");
@@ -325,13 +326,14 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(1)).getTitle();
         verify(ghPullRequest, times(6)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
-        verify(ghPullRequest, times(8)).getHead();
+        verify(ghPullRequest, times(9)).getHead();
         verify(ghPullRequest, times(1)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
         verify(ghPullRequest, times(1)).getHtmlUrl();
-        verify(ghPullRequest, times(3)).getUpdatedAt();
+        verify(ghPullRequest, times(2)).getUpdatedAt();
+        verify(ghPullRequest, times(1)).getCreatedAt();
 
-        verify(ghPullRequest, times(1)).getComments();
+        verify(ghPullRequest, times(2)).getComments();
         verify(ghPullRequest, times(1)).listCommits();
         verify(ghPullRequest, times(1)).getBody();
         verify(ghPullRequest, times(1)).getId();
@@ -357,7 +359,9 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghUser);
     }
 
-    private List<GHPullRequest> createListWithMockPR() {
+    private List<GHPullRequest> createListWithMockPR() throws IOException {
+
+        given(ghPullRequest.getCreatedAt()).willReturn(new Date());
         List<GHPullRequest> ghPullRequests = new ArrayList<GHPullRequest>();
         ghPullRequests.add(ghPullRequest);
         return ghPullRequests;
@@ -374,9 +378,7 @@ public class GhprbRepositoryTest {
         mockCommitList();
         GhprbBuilds builds = mockBuilds();
 
-        given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
-
-        given(ghPullRequest.getUpdatedAt()).willReturn(now).willReturn(now).willReturn(tomorrow);
+        given(ghPullRequest.getUpdatedAt()).willReturn(now).willReturn(tomorrow);
         given(ghPullRequest.getNumber()).willReturn(100);
         given(ghPullRequest.getMergeable()).willReturn(true);
         given(ghPullRequest.getTitle()).willReturn("title");
@@ -385,6 +387,7 @@ public class GhprbRepositoryTest {
         given(ghPullRequest.getApiURL()).willReturn(new URL("https://github.com/org/repo/pull/100"));
         given(ghPullRequest.getId()).willReturn(100);
         given(ghRepository.getPullRequest(ghPullRequest.getId())).willReturn(ghPullRequest);
+        given(ghRepository.getPullRequests(eq(GHIssueState.OPEN))).willReturn(ghPullRequests);
         
         given(ghUser.getEmail()).willReturn("email");
         given(ghUser.getLogin()).willReturn("login");
@@ -418,7 +421,8 @@ public class GhprbRepositoryTest {
         verify(ghPullRequest, times(10)).getHead();
         verify(ghPullRequest, times(2)).getBase();
         verify(ghPullRequest, times(5)).getNumber();
-        verify(ghPullRequest, times(3)).getUpdatedAt();
+        verify(ghPullRequest, times(2)).getUpdatedAt();
+        verify(ghPullRequest, times(1)).getCreatedAt();
         verify(ghPullRequest, times(2)).getHtmlUrl();
 
         verify(ghPullRequest, times(1)).getId();
@@ -558,7 +562,7 @@ public class GhprbRepositoryTest {
 
         pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>();
         ghprbRepository = new GhprbRepository(TEST_USER_NAME, TEST_REPO_NAME, trigger);
-        ghprbPullRequest = new GhprbPullRequest(ghPullRequest, helper, ghprbRepository);
+        ghprbPullRequest = new GhprbPullRequest(ghPullRequest, helper, ghprbRepository, false);
         
         given(trigger.getPullRequests()).willReturn(pulls);
 

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -560,7 +560,7 @@ public class GhprbRepositoryTest {
         ghprbRepository = new GhprbRepository(TEST_USER_NAME, TEST_REPO_NAME, trigger);
         ghprbPullRequest = new GhprbPullRequest(ghPullRequest, helper, ghprbRepository);
         
-        given(trigger.getPulls()).willReturn(pulls);
+        given(trigger.getPullRequests()).willReturn(pulls);
 
         // Reset mocks not to mix init data invocations with tests
         reset(ghPullRequest, ghUser, helper, head, base);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbRepositoryTest.java
@@ -242,7 +242,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(7)).getUser();
+        verify(ghPullRequest, times(6)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(7)).getHead();
         verify(ghPullRequest, times(1)).getBase();
@@ -262,7 +262,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(2)).getEmail(); // Call to Github API
+        verify(ghUser, times(1)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verifyNoMoreInteractions(ghUser);
     }
@@ -323,7 +323,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(1)).getTitle();
-        verify(ghPullRequest, times(7)).getUser();
+        verify(ghPullRequest, times(6)).getUser();
         verify(ghPullRequest, times(1)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(8)).getHead();
         verify(ghPullRequest, times(1)).getBase();
@@ -351,7 +351,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(2)).getEmail(); // Call to Github API
+        verify(ghUser, times(1)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verify(ghUser, times(1)).getName();
         verifyNoMoreInteractions(ghUser);
@@ -413,7 +413,7 @@ public class GhprbRepositoryTest {
         verifyNoMoreInteractions(ghRepository);
 
         verify(ghPullRequest, times(2)).getTitle();
-        verify(ghPullRequest, times(9)).getUser();
+        verify(ghPullRequest, times(7)).getUser();
         verify(ghPullRequest, times(2)).getMergeable(); // Call to Github API
         verify(ghPullRequest, times(10)).getHead();
         verify(ghPullRequest, times(2)).getBase();
@@ -441,7 +441,7 @@ public class GhprbRepositoryTest {
         verify(helper, times(2)).checkSkipBuild(eq(ghPullRequest));
         verifyNoMoreInteractions(helper);
 
-        verify(ghUser, times(3)).getEmail(); // Call to Github API
+        verify(ghUser, times(1)).getEmail(); // Call to Github API
         verify(ghUser, times(1)).getLogin();
         verify(ghUser, times(1)).getName();
         verifyNoMoreInteractions(ghUser);

--- a/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
+++ b/src/test/java/org/jenkinsci/plugins/ghprb/GhprbTestUtil.java
@@ -388,7 +388,7 @@ public class GhprbTestUtil {
         given(github.getRateLimit()).willReturn(limit);
 
         ConcurrentMap<Integer, GhprbPullRequest> pulls = new ConcurrentHashMap<Integer, GhprbPullRequest>(1);
-        Mockito.doReturn(pulls).when(trigger).getPulls();
+        Mockito.doReturn(pulls).when(trigger).getPullRequests();
         Mockito.doReturn(github).when(trigger).getGitHub();
         
         return trigger;


### PR DESCRIPTION
@mmitche I don't think that the save step can be fully removed, but with how I have moved things around the saving should be done on a job by job basis.  There just isn't any way around having to update the config.xml after each run.  